### PR TITLE
Add kubectl and helm to Dockerfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "docker build -t k8s-sherlock:latest ."
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Ubuntu runtime as base image
-FROM ubuntu:noble
+FROM ubuntu:latest
 
 # Set up environment variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -62,6 +62,14 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform
 RUN wget https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
     chmod +x terragrunt_linux_amd64 && \
     mv terragrunt_linux_amd64 /usr/local/bin/terragrunt
+
+# Install kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/kubectl
+
+# Install helm
+RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
 # Set entrypoint to bash
 ENTRYPOINT ["/bin/bash"]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -8,12 +8,20 @@ docker build -t test-image .
 
 # Run the container
 echo "Running Docker container..."
-container_id=$(docker run -it --rm test-image:latest)
+container_id=$(docker run -d test-image:latest)
 
 # Helper function to run commands inside the container
 run_command() {
   docker exec $container_id "$@"
 }
+
+# Test kubectl installation
+echo "Testing kubectl installation..."
+run_command kubectl version --client
+
+# Test helm installation
+echo "Testing helm installation..."
+run_command helm version
 
 # All tests passed
 echo "All tests passed successfully."


### PR DESCRIPTION
Update Dockerfile to use latest Ubuntu image and add kubectl and helm installations.

* **Dockerfile**
  - Change base image from `ubuntu:noble` to `ubuntu:latest`.
  - Add installation steps for `kubectl`.
  - Add installation steps for `helm`.

* **tests/test.sh**
  - Modify container run command to run in detached mode.
  - Add tests to verify `kubectl` installation.
  - Add tests to verify `helm` installation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vivsoftorg/k8s-sherlock/pull/4?shareId=01e15db0-38a5-4ddc-a2f9-c338ac5c0db1).